### PR TITLE
Add BenchmarkDotNet project for current builders

### DIFF
--- a/tests/Blazor.ClassBuilder.Benchmarks/Blazor.ClassBuilder.Benchmarks.csproj
+++ b/tests/Blazor.ClassBuilder.Benchmarks/Blazor.ClassBuilder.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Blazor.ClassBuilder\Blazor.ClassBuilder.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Blazor.ClassBuilder.Benchmarks/ClassBuilderBenchmarks.cs
+++ b/tests/Blazor.ClassBuilder.Benchmarks/ClassBuilderBenchmarks.cs
@@ -1,0 +1,40 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Blazor.ClassBuilder.Benchmarks
+{
+    /// <summary>
+    /// Models the real SatisFIT chain ListRowOption._listRowClasses: one constant, one AddIfElse,
+    /// and five AddIf with all-literal fragments.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class ClassBuilderBenchmarks
+    {
+        private const string Base = "flex flex-col";
+        private const string WidthOptimized = "grow shrink-0 basis-0";
+        private const string FlexAuto = "flex-auto";
+        private const string SelectedFilled = "bg-gradient-to-t from-gray-100 to-gray-50";
+        private const string SelectedNotFilled = "bg-yellow-300";
+        private const string NotSelectedDefault = "bg-theme-yellow-light";
+        private const string Cursor = "cursor-pointer";
+        private const string Border = "border-r border-gray-200";
+
+        private readonly bool _isWidthOptimized = true;
+        private readonly bool _isSelected = true;
+        private readonly bool _isFilled = false;
+        private readonly bool _isDisabled = false;
+
+        [Benchmark]
+        public string ListRowClasses()
+        {
+            return new ClassBuilder()
+                .Add(Base)
+                .AddIfElse(_isWidthOptimized, WidthOptimized, FlexAuto)
+                .AddIf(_isSelected && _isFilled, SelectedFilled)
+                .AddIf(_isSelected && !_isFilled, SelectedNotFilled)
+                .AddIf(!_isDisabled && !_isFilled && !_isSelected, NotSelectedDefault)
+                .AddIf(!_isDisabled, Cursor)
+                .AddIf(!_isSelected, Border)
+                .Build();
+        }
+    }
+}

--- a/tests/Blazor.ClassBuilder.Benchmarks/Program.cs
+++ b/tests/Blazor.ClassBuilder.Benchmarks/Program.cs
@@ -1,0 +1,7 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+public partial class Program
+{
+}

--- a/tests/Blazor.ClassBuilder.Benchmarks/StyleAndAttributeBenchmarks.cs
+++ b/tests/Blazor.ClassBuilder.Benchmarks/StyleAndAttributeBenchmarks.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Globalization;
+using BenchmarkDotNet.Attributes;
+
+namespace Blazor.ClassBuilder.Benchmarks
+{
+    /// <summary>
+    /// Models the real SatisFIT AdaptiveVirtualize styles: a container style that is static across
+    /// renders and a per-item style whose translateY changes every render, the way a scrolling list
+    /// produces a new value on each frame.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class StyleBuilderBenchmarks
+    {
+        private int _offset;
+
+        [Benchmark]
+        public string ContainerStyle()
+        {
+            return new StyleBuilder()
+                .Add("position", "relative")
+                .Add("width", "100%")
+                .Add("height", "1200px")
+                .Build();
+        }
+
+        [Benchmark]
+        public string ItemStyle()
+        {
+            var translate = $"translateY({NextOffset().ToString(CultureInfo.InvariantCulture)}px)";
+
+            return new StyleBuilder()
+                .Add("position", "absolute")
+                .Add("top", "0")
+                .Add("left", "0")
+                .Add("width", "100%")
+                .Add("transform", translate)
+                .Build();
+        }
+
+        private int NextOffset()
+        {
+            _offset += 40;
+
+            return _offset;
+        }
+    }
+
+    /// <summary>
+    /// Models the real SatisFIT chain LazyImage._imageAttributes: two unconditional attributes and
+    /// three conditional ones.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class AttributeBuilderBenchmarks
+    {
+        private const string Src = "https://cdn.satis.fit/exercise/123.webp?v=42";
+        private const string Alt = "Barbell back squat";
+
+        private readonly bool _isLazy = true;
+        private readonly bool _hasSyncDecoding = true;
+        private readonly bool _shouldUseCors = false;
+
+        [Benchmark]
+        public Dictionary<string, object> ImageAttributes()
+        {
+            return new AttributeBuilder()
+                .Add("src", Src)
+                .Add("alt", Alt)
+                .AddIf(_isLazy, "loading", "lazy")
+                .AddIf(_hasSyncDecoding, "decoding", "sync")
+                .AddIf(_shouldUseCors, "crossorigin", "anonymous")
+                .Build();
+        }
+    }
+}

--- a/tests/Blazor.ClassBuilder.Benchmarks/StyleAndAttributeBenchmarks.cs
+++ b/tests/Blazor.ClassBuilder.Benchmarks/StyleAndAttributeBenchmarks.cs
@@ -6,13 +6,14 @@ namespace Blazor.ClassBuilder.Benchmarks
 {
     /// <summary>
     /// Models the real SatisFIT AdaptiveVirtualize styles: a container style that is static across
-    /// renders and a per-item style whose translateY changes every render, the way a scrolling list
-    /// produces a new value on each frame.
+    /// renders and a per-item style that includes an interpolated translateY transform (the dynamic
+    /// part of a virtualized list item). A fixed representative offset keeps every measured
+    /// invocation comparable.
     /// </summary>
     [MemoryDiagnoser]
     public class StyleBuilderBenchmarks
     {
-        private int _offset;
+        private const int ItemOffsetPx = 4080;
 
         [Benchmark]
         public string ContainerStyle()
@@ -27,7 +28,7 @@ namespace Blazor.ClassBuilder.Benchmarks
         [Benchmark]
         public string ItemStyle()
         {
-            var translate = $"translateY({NextOffset().ToString(CultureInfo.InvariantCulture)}px)";
+            var translate = $"translateY({ItemOffsetPx.ToString(CultureInfo.InvariantCulture)}px)";
 
             return new StyleBuilder()
                 .Add("position", "absolute")
@@ -36,13 +37,6 @@ namespace Blazor.ClassBuilder.Benchmarks
                 .Add("width", "100%")
                 .Add("transform", translate)
                 .Build();
-        }
-
-        private int NextOffset()
-        {
-            _offset += 40;
-
-            return _offset;
         }
     }
 


### PR DESCRIPTION
Adds a `Blazor.ClassBuilder.Benchmarks` project that measures the current behavior of all three builders, using realistic chains taken from the SatisFIT codebase:

- **ClassBuilder** - `ListRowOption._listRowClasses` (one constant + AddIfElse + five AddIf, all-literal fragments)
- **StyleBuilder** - `AdaptiveVirtualize` container style (static) and per-item style (dynamic translateY that changes each render)
- **AttributeBuilder** - `LazyImage._imageAttributes` (two unconditional + three conditional attributes)

Run with:

```bash
dotnet run -c Release --project tests/Blazor.ClassBuilder.Benchmarks -- --filter "*"
```

`MemoryDiagnoser` is enabled so allocations are reported alongside timings. This establishes a baseline for the current functionality; no library code is changed.